### PR TITLE
Add slack_id to all return responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # socless-slack
 
 # Deployment Instructions
+
 ## Prerequisites
+
 - A Slack instance
 - Permissions to create a Slack bot
 - Socless Automation Framework deployed in an AWS Account
 
 ## Setting up a Slack bot
+
 This integration requires a Slack bot setup and configured.
 To setup a Slack bot:
+
 1. In a web browser, log into the Slack instance you want your bot to exist in
 2. Navigate to api.slack.com/apps and hit `Create New App`
 3. Enter a name for your application. The tutorial will use `socless-bot`
@@ -26,8 +30,8 @@ To setup a Slack bot:
 
 *Tip:* Consider configuring one Slack bot for each Socless environment you have. Doing so will simplify playbook testing
 
-
 ## Configure Parameters in AWS SSM Parameter Store
+
 Configure the below parameters in AWS Systems Manager (SSM) Parameter Store in the region(s) you plan to deploy your Socless Slack integrations
 
 | Key                               | Value description                                                                                                                                                         | Parameter Type |
@@ -36,7 +40,6 @@ Configure the below parameters in AWS Systems Manager (SSM) Parameter Store in t
 | /socless/slack/slash_command      | The name you'll give the slash command for your bot e.g /socless-bot                                                                                                      | String         |
 | /socless/slack/signing_secret     | The signing secret for your bot found on the "App Credentials" section of the "Basic Information" page for your app                                                       | SecureString   |
 | /socless/slack_endpoint/help_text | Help text that your Socless Slack endpoints will respond with in case of failure e.g. "socless-bot experienced an error. Please contact the security team for assistance" | SecureString   |
-
 
 
 To configure the parameters,

--- a/functions/find_user/lambda_function.py
+++ b/functions/find_user/lambda_function.py
@@ -40,7 +40,7 @@ def handle_state(username,exclude_bots="false"):
     result['profile']['last_name'] = profile.get('last_name') or 'N/A'
     result['name'] = user.get('name') or 'N/A'
     result['profile']['email'] = profile.get('email') or 'N/A'
-    result["id"] = user['id']
+    result['id'] = user['id']
     return result
 
 def lambda_handler(event,context):

--- a/functions/prompt_for_confirmation/lambda_function.py
+++ b/functions/prompt_for_confirmation/lambda_function.py
@@ -52,7 +52,7 @@ def handle_state(context, receiver, target_type, target, text, prompt_text='', y
     execution_id = context.get('execution_id')
     if resp.data['ok']:
         socless_dispatch_outbound_message(receiver, message_id, investigation_id, execution_id, resp.data)
-        return {"response": resp.data, "message_id": message_id}
+        return {"response": resp.data, "message_id": message_id, "slack_id" : target_id}
     else:
         raise Exception(f"Failed to initiate human response workflow: {resp.data}")
 

--- a/functions/prompt_for_response/lambda_function.py
+++ b/functions/prompt_for_response/lambda_function.py
@@ -29,7 +29,7 @@ def handle_state(context,receiver,target,target_type,message_template,response_d
         socless_dispatch_outbound_message(receiver,message_id,investigation_id,execution_id,message)
     else:
         raise Exception(f"Human Reponse workflow failed to initiate because slack_client failed to send message: {r.data}")
-    return {"response": r.data, "message_id": message_id}
+    return {"response": r.data, "message_id": message_id, "slack_id" : target_id}
 
 
 def lambda_handler(event,context):

--- a/functions/send_message/lambda_function.py
+++ b/functions/send_message/lambda_function.py
@@ -13,7 +13,7 @@ def handle_state(context, message_template, target, target_type):
     target_id = get_channel_id(target, target_type)
     message = socless_template_string(message_template, context)
     resp = slack_client.chat_postMessage(channel=target_id, text=message, as_user=True)
-    return {"response": resp.data}
+    return {"response": resp.data, "slack_id": target_id}
 
 
 def lambda_handler(event, context):


### PR DESCRIPTION
Whenever a slack function sends a message to a user or channel, it needs to either find the user's slack_id or format the channel name into a slack_id for the actual slack API calls. Converting a username into a slack_id can be an expensive process involving pagination of your workspace's entire user list. In a large Step Functions playbook, doing this multiple times can result in errors from slack rate limiting these API calls. 
By returning the "slack_id" in every slack lambda function, you can reference this id later in the playbook if you are messaging the same user repeatedly. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
