### PR TITLE
Remove unused imports

### DIFF
--- a/functions/check_user_in_channel/lambda_function.py
+++ b/functions/check_user_in_channel/lambda_function.py
@@ -1,5 +1,5 @@
 from socless import *
-from slack_helpers import slack_client, find_user, get_channel_id, paginated_api_call
+from slack_helpers import slack_client, paginated_api_call
 
 
 def handle_state(user_id, target_channel_id):

--- a/functions/find_user/lambda_function.py
+++ b/functions/find_user/lambda_function.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 from socless import *
-from slack_helpers import slack_client, find_user
-import os
+from slack_helpers import find_user
 
 
 def handle_state(username,exclude_bots="false"):

--- a/functions/list_channels/lambda_function.py
+++ b/functions/list_channels/lambda_function.py
@@ -1,5 +1,5 @@
 from socless import *
-from slack_helpers import slack_client, find_user, get_channel_id, paginated_api_call
+from slack_helpers import slack_client, paginated_api_call
 
 
 def handle_state():

--- a/functions/prompt_for_confirmation/lambda_function.py
+++ b/functions/prompt_for_confirmation/lambda_function.py
@@ -1,6 +1,6 @@
 from socless import socless_template_string, socless_dispatch_outbound_message, socless_bootstrap
 from socless.utils import gen_id
-from slack_helpers import find_user, get_channel_id, slack_client
+from slack_helpers import get_channel_id, slack_client
 
 
 def handle_state(context, receiver, target_type, target, text, prompt_text='', yes_text='Yes', no_text='No'):


### PR DESCRIPTION
Removed unused imports from few helper functions:

1. check_user_in_channel
2. find_user
3. list_channels
4. prompt_for_confirmation

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
