### PR TITLE
Remove unused imports from prompt_for_response and send_message

### DIFF
--- a/functions/prompt_for_response/lambda_function.py
+++ b/functions/prompt_for_response/lambda_function.py
@@ -1,5 +1,5 @@
-import uuid, os
-from slack_helpers import slack_client, find_user, get_channel_id
+import os
+from slack_helpers import slack_client, get_channel_id
 from socless import socless_bootstrap, socless_dispatch_outbound_message, socless_template_string
 from socless.utils import gen_id
 

--- a/functions/send_message/lambda_function.py
+++ b/functions/send_message/lambda_function.py
@@ -1,6 +1,5 @@
 from socless import *
-from slack_helpers import slack_client, find_user, get_channel_id
-import slack
+from slack_helpers import slack_client, get_channel_id
 
 
 def handle_state(context, message_template, target, target_type):


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Removed unused imports from the following helper functions:
1. prompt_for_response
2. send_message

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
