### PR TITLE
Fix private channel creation, invite list of users, better logging for dialog errors

### DIFF
--- a/functions/create_channel/lambda_function.py
+++ b/functions/create_channel/lambda_function.py
@@ -1,13 +1,16 @@
-from socless import *
+from socless import socless_bootstrap
 import os
 import slack
 
+SOCLESS_USER_TOKEN = os.environ["SOCLESS_USER_TOKEN"]
+slack_api_client = slack.WebClient(SOCLESS_USER_TOKEN)
 
-def handle_state(channel_name, user_ids, is_private=False):
-    """ Create slack channel
+
+def handle_state(channel_name, user_ids=[], is_private=False):
+    """Create slack channel and invite any provided slack_ids.
     Args:
         channel_name (str): The name of channel to be created.
-        user_ids (list) : list of all users to be added to channel.
+        user_ids (list) : slack_ids of users invited to new channel. Private Channels require a user.
         is_private (boolean): if the channel is private.
     Token_Type: xoxp (slack legacy user token)
     Note:
@@ -15,34 +18,24 @@ def handle_state(channel_name, user_ids, is_private=False):
     """
 
     if isinstance(user_ids, str):
-        user_ids = [ user_ids ]
-
-    SOCLESS_USER_TOKEN = os.environ['SOCLESS_USER_TOKEN']
-    slack_api_client = slack.WebClient(SOCLESS_USER_TOKEN)
+        user_ids = [user_ids]
 
     try:
-        res = slack_api_client.conversations_create(
-            name=channel_name,
-            is_private=is_private,
-            user_ids=user_ids
+        response = slack_api_client.conversations_create(
+            name=channel_name, is_private=is_private, user_ids=user_ids
         )
-
-        print(res)
-
-        created_channel_id = res["channel"]['id']
+        print(response)
+        created_channel_id = response["channel"]["id"]
 
         return {
             "ok": True,
             "created_channel_id": created_channel_id,
-            "channel_name": channel_name
-            "added_users" : user_ids
+            "channel_name": channel_name,
+            "added_users": user_ids,
         }
     except Exception as e:
         s = str(e)
-        return {
-            "ok": False,
-            "error": s
-        }
+        return {"ok": False, "error": s}
 
 
 def lambda_handler(event, context):

--- a/functions/create_channel/lambda_function.py
+++ b/functions/create_channel/lambda_function.py
@@ -3,16 +3,19 @@ import os
 import slack
 
 
-def handle_state(channel_name, is_private):
+def handle_state(channel_name, user_ids, is_private=False):
+    """ Create slack channel
+    Args:
+        channel_name (str): The name of channel to be created.
+        user_ids (list) : list of all users to be added to channel.
+        is_private (boolean): if the channel is private.
+    Token_Type: xoxp (slack legacy user token)
+    Note:
+        - See https://api.slack.com/methods/conversations.create for more details on how to create private channel
     """
-       Create slack channel
-       Args:
-                  channel_name (str): The name of channel to be created.
-                  is_private (boolean): if the channel private
-       Token_Type: xoxp
-       Note:
-                  - See https://api.slack.com/methods/conversations.create for more details on how to create private channel
-       """
+
+    if isinstance(user_ids, str):
+        user_ids = [ user_ids ]
 
     SOCLESS_USER_TOKEN = os.environ['SOCLESS_USER_TOKEN']
     slack_api_client = slack.WebClient(SOCLESS_USER_TOKEN)
@@ -20,8 +23,12 @@ def handle_state(channel_name, is_private):
     try:
         res = slack_api_client.conversations_create(
             name=channel_name,
-            is_private=is_private
+            is_private=is_private,
+            user_ids=user_ids
         )
+
+        print(res)
+
         created_channel_id = res["channel"]['id']
         return {
             "ok": True,

--- a/functions/create_channel/lambda_function.py
+++ b/functions/create_channel/lambda_function.py
@@ -30,18 +30,18 @@ def handle_state(channel_name, user_ids, is_private=False):
         print(res)
 
         created_channel_id = res["channel"]['id']
+
         return {
             "ok": True,
             "created_channel_id": created_channel_id,
             "channel_name": channel_name
+            "added_users" : user_ids
         }
     except Exception as e:
         s = str(e)
-        err_msg = s.split("'detail': ", 1)[1]
-        err_msg = err_msg[:len(err_msg) - 1]
         return {
             "ok": False,
-            "error": err_msg
+            "error": s
         }
 
 

--- a/functions/invite_to_channel/lambda_function.py
+++ b/functions/invite_to_channel/lambda_function.py
@@ -1,36 +1,34 @@
-from socless import *
+from socless import socless_bootstrap
 import slack
 import os
 
-def handle_state(channel_id, user_ids):
+
+def handle_state(channel_id, user_id="", user_ids=[]):
     """Add people to the channel.
         Args:
             channel_id (str): Id of channel to invite.
-            user_ids (str):  user id to invite.
+            user_id (str) : [deprecated] single id of user to invite. Ex. W1234567
+            user_ids (list): list of slack user_ids id to invite. Ex. [W12345, U12348]
         Note:
             Token_Type: xoxp
             - See https://api.slack.com/methods/conversations.invite for more details on how to create private channel
         """
-    SOCLESS_USER_TOKEN = os.environ['SOCLESS_USER_TOKEN']
+    SOCLESS_USER_TOKEN = os.environ["SOCLESS_USER_TOKEN"]
     slack_api_client = slack.WebClient(SOCLESS_USER_TOKEN)
 
-    # if userids is a string (single id), convert to list
     if isinstance(user_ids, str):
-        user_ids = [ user_ids ]
+        user_ids = [user_ids]
+
+    if user_id:
+        user_ids.append(user_id)
 
     try:
         res = slack_api_client.conversations_invite(channel=channel_id, users=user_ids)
-        created_channel_id = res["channel"]['id']
-        return {
-            "ok": True,
-            "created_channel_id": created_channel_id
-        }
+        created_channel_id = res["channel"]["id"]
+        return {"ok": True, "created_channel_id": created_channel_id}
     except Exception as e:
         s = str(e)
-        return {
-            "ok": False,
-            "error": s
-        }
+        return {"ok": False, "error": s}
 
 
 def lambda_handler(event, context):

--- a/functions/invite_to_channel/lambda_function.py
+++ b/functions/invite_to_channel/lambda_function.py
@@ -2,20 +2,24 @@ from socless import *
 import slack
 import os
 
-def handle_state(channel_id, user_id):
-    """
-        Add people to the channel
-          Args:
-                     channel_id (str): Id of channel to invite.
-                     user_id (str):  user id to invite.
-        Token_Type: xoxp
+def handle_state(channel_id, user_ids):
+    """Add people to the channel.
+        Args:
+            channel_id (str): Id of channel to invite.
+            user_ids (str):  user id to invite.
         Note:
-                     - See https://api.slack.com/methods/conversations.invite for more details on how to create private channel
-          """
+            Token_Type: xoxp
+            - See https://api.slack.com/methods/conversations.invite for more details on how to create private channel
+        """
     SOCLESS_USER_TOKEN = os.environ['SOCLESS_USER_TOKEN']
     slack_api_client = slack.WebClient(SOCLESS_USER_TOKEN)
+
+    # if userids is a string (single id), convert to list
+    if isinstance(user_ids, str):
+        user_ids = [ user_ids ]
+
     try:
-        res = slack_api_client.conversations_invite(channel=channel_id, users=[user_id])
+        res = slack_api_client.conversations_invite(channel=channel_id, users=user_ids)
         created_channel_id = res["channel"]['id']
         return {
             "ok": True,

--- a/functions/set_channel_topic/lambda_function.py
+++ b/functions/set_channel_topic/lambda_function.py
@@ -8,6 +8,9 @@ def handle_state(channel_id, topic):
     Args:
         channel_id(str): channel_id for the targeted channel
         topic(str): topic to set to channel
+
+    This is currently deprecated for BOT_TOKENS and requires a user token (see:
+    https://api.slack.com/methods/conversations.setTopic).
     """
     topic = topic or ""
     SOCLESS_USER_TOKEN = os.environ['SOCLESS_USER_TOKEN']


### PR DESCRIPTION
- Allow inviting multiple users in `invite_to_channel` and `create_channel` via the new `user_ids` parameter
- Retain `user_id` parameter to keep backwards compatibility
- Log response metadata when slack send_dialog API call fails (often includes validation error specifics for easy debugging)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
