### PR TITLE
Turn as_user as a optional param

### DIFF
--- a/functions/send_message/lambda_function.py
+++ b/functions/send_message/lambda_function.py
@@ -3,7 +3,7 @@ from slack_helpers import slack_client, find_user, get_channel_id
 import slack
 
 
-def handle_state(context, message_template, target, target_type):
+def handle_state(context, message_template, target, target_type, as_user=True):
     """
     Send a Slack message without expecting a response
     """
@@ -12,7 +12,7 @@ def handle_state(context, message_template, target, target_type):
 
     target_id = get_channel_id(target, target_type)
     message = socless_template_string(message_template, context)
-    resp = slack_client.chat_postMessage(channel=target_id, text=message, as_user=True)
+    resp = slack_client.chat_postMessage(channel=target_id, text=message, as_user=as_user)
     return {"response": resp.data, "slack_id": target_id}
 
 


### PR DESCRIPTION
Making as_user an optional param, this should be backward compatible with all existing running integration, while giving future integrations more flexibility 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
