### PR TITLE
deprecate socless_template_string

### DIFF
--- a/functions/prompt_for_confirmation/lambda_function.py
+++ b/functions/prompt_for_confirmation/lambda_function.py
@@ -1,5 +1,4 @@
 from socless import (
-    socless_template_string,
     socless_dispatch_outbound_message,
     socless_bootstrap,
     init_human_interaction,
@@ -63,8 +62,6 @@ def handle_state(
 
     message_id = gen_id(6)
     context["_message_id"] = message_id
-    text = socless_template_string(text, context)
-    prompt_text = socless_template_string(prompt_text, context)
 
     ATTACHMENT_TEMPLATE["text"] = "*{}*".format(prompt_text)
     ATTACHMENT_TEMPLATE["callback_id"] = message_id

--- a/functions/prompt_for_response/lambda_function.py
+++ b/functions/prompt_for_response/lambda_function.py
@@ -3,7 +3,6 @@ from slack_helpers import SlackHelper
 from socless import (
     socless_bootstrap,
     socless_dispatch_outbound_message,
-    socless_template_string,
     init_human_interaction,
 )
 from socless.utils import gen_id
@@ -47,7 +46,7 @@ def handle_state(
         context=context,
         response_desc=response_desc,
     )
-    message = socless_template_string(extended_template, context)
+    message = extended_template
 
     if USE_NEW_INTERACTION:
         init_human_interaction(context, message, message_id)

--- a/functions/send_message/lambda_function.py
+++ b/functions/send_message/lambda_function.py
@@ -1,4 +1,4 @@
-from socless import socless_bootstrap, socless_template_string
+from socless import socless_bootstrap
 from slack_helpers import SlackHelper
 
 
@@ -25,7 +25,7 @@ def handle_state(
             "Incomplete parameters supplied. Please supply target, target_type and message_template"
         )
 
-    message = socless_template_string(message_template, context)
+    message = message_template
 
     resp = helper.slack_post_msg_wrapper(
         target, target_type, text=message, as_user=as_user

--- a/functions/upload_file/lambda_function.py
+++ b/functions/upload_file/lambda_function.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from socless import socless_bootstrap, socless_template_string
+from socless import socless_bootstrap
 from slack_helpers import SlackError, SlackHelper
 
 
@@ -35,8 +35,6 @@ def handle_state(
         raise SlackError(
             "Incomplete parameters supplied. Please `supply target`, `target_type`"
         )
-
-    content = socless_template_string(content, context)
 
     slack_target = helper.resolve_slack_target(target, target_type)
 


### PR DESCRIPTION
This is to deprecate old API: socless_template_string.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
