### PR TITLE
Add SOCless Slack Function to find user via email

### DIFF
--- a/common_files/slack_helpers.py
+++ b/common_files/slack_helpers.py
@@ -3,6 +3,7 @@ import boto3
 from slack_sdk import WebClient
 from slack_sdk.signature import SignatureVerifier
 from slack_sdk.web.slack_response import SlackResponse
+from boto3.dynamodb.conditions import Attr
 
 CACHE_USERS_TABLE = os.environ.get("CACHE_USERS_TABLE")
 SOCLESS_BOT_TOKEN = os.environ["SOCLESS_BOT_TOKEN"]
@@ -33,37 +34,49 @@ class SlackHelper:
             token = SOCLESS_BOT_TOKEN
         self.client = WebClient(token)
 
-    def find_user(self, name: str, page_limit=1000, include_locale="false"):
-        """Find a user's Slack profile based on their full or display name.
+    def find_user(self, name="", email="", page_limit=1000, include_locale="false"):
+        """Find a user's Slack profile based on their full or display name, or via email
         Args:
             name: A user's Full Name or Display Name
+            email: A user's email
         """
+        if not name and not email:
+            return {"found": False}         
         name_lower = name.lower()
         paginate = True
         next_cursor = ""
-        while paginate:
-            resp = self.client.users_list(
-                cursor=next_cursor, limit=page_limit, include_locale=include_locale
-            )
-            data = resp.data
-            next_cursor = resp.data["response_metadata"].get("next_cursor", "")
-            if not next_cursor:
-                paginate = False
-
-            for user in data["members"]:
-                user_names = list(
-                    map(
-                        str.lower,
-                        [
-                            user.get("name", ""),
-                            user.get("real_name", ""),
-                            user.get("profile", {}).get("real_name", ""),
-                        ],
+        if email:
+            try:
+                resp = self.client.users_lookupByEmail(email = email.lower())
+                data = resp.data
+                if data["ok"]:
+                    return {"found": True, "user": data["user"]}
+            except Exception:
+                return {"found": False} 
+        if name: 
+                while paginate:
+                    resp = self.client.users_list(
+                        cursor=next_cursor, limit=page_limit, include_locale=include_locale
                     )
-                )
-                if name_lower in user_names:
-                    return {"found": True, "user": user}
-
+                    data = resp.data
+                    next_cursor = resp.data["response_metadata"].get("next_cursor", "")
+                    if not next_cursor:
+                        paginate = False
+                    for user in data["members"]:
+                        user_names = list(
+                            map(
+                                str.lower,
+                                [
+                                    user.get("name", ""),
+                                    user.get("real_name", ""),
+                                    user.get("profile", {}).get("real_name", ""),
+                                    user.get("profile", {}).get("display_name", "")
+                                ],
+                            )
+                        )
+                        if name_lower in user_names:
+                            return {"found": True, "user": user}
+        
         return {"found": False}
 
     def get_slack_id_from_username(self, username: str):
@@ -75,16 +88,41 @@ class SlackHelper:
         Returns:
             slack_id
         """
-        slack_id = get_id_from_cache(username) if CACHE_USERS_TABLE else ""
+        slack_id = get_id_from_cache(username=username) if CACHE_USERS_TABLE else ""
 
         if not slack_id:
-            search = self.find_user(username)
+            search = self.find_user(name=username)
             if not search["found"]:
                 raise Exception(f"Unable to find user: {username}")
 
             slack_id = search["user"]["id"]
+            email = search["user"]["profile"]["email"]
             if CACHE_USERS_TABLE:
-                save_user_to_cache(username=username, slack_id=slack_id)
+                save_user_to_cache(username=username, email=email, slack_id=slack_id)
+
+        return slack_id
+
+    def get_slack_id_from_email(self, email: str):
+        """Fetch user's slack_id from their email.
+        Checks against the dynamoDB cache (if enabled), or paginates through slack API users.lookupByEmail
+            looking for the supplied email. If cache enabled, saves the found slack_id
+        Args:
+            email : (string) slack user's email
+        Returns:
+            slack_id
+        """
+        slack_id = get_id_from_cache(email=email) if CACHE_USERS_TABLE else ""
+
+        if not slack_id:
+            search = self.find_user(email=email)
+            if not search["found"]:
+                raise Exception(f"Unable to find user using email: {email}")
+
+            slack_id = search["user"]["id"]
+            #starting 2017(https://api.slack.com/changelog/2017-09-the-one-about-usernames), use display_name to map to slack Id)
+            username = search["user"]["profile"]["display_name"]
+            if CACHE_USERS_TABLE:
+                save_user_to_cache(username=username, email=email, slack_id=slack_id)
 
         return slack_id
 
@@ -106,11 +144,13 @@ class SlackHelper:
             slack_id = target_name
         elif target_type == "user":
             slack_id = self.get_slack_id_from_username(target_name)
+        elif target_type == "email":
+            slack_id = self.get_slack_id_from_email(target_name)            
         elif target_type == "channel":
             slack_id = target_name if target_name.startswith("#") else f"#{target_name}"
         else:
             raise Exception(
-                f"target_type is not 'channel|user|slack_id'. failed target_type: {target_type} for target: {target_name}"
+                f"target_type is not 'channel|user|email|slack_id'. failed target_type: {target_type} for target: {target_name}"
             )
 
         return slack_id
@@ -127,29 +167,35 @@ class SlackHelper:
         return resp
 
 
-def get_id_from_cache(username: str) -> str:
-    """Check if username exists in cache, return their slack_id.
+def get_id_from_cache(username="", email="") -> str:
+    """Check if username or email exists in cache, return their slack_id.
     Args:
         username: slack username
+        email: slack user's email
     Returns:
         slack_id
     """
+    if not username and not email: 
+        return False
     dynamodb = boto3.resource("dynamodb")
     if not CACHE_USERS_TABLE:
         raise Exception(
             "env var CACHE_USERS_TABLE is not set, please check socless-slack serverless.yml"
         )
     table_resource = dynamodb.Table(CACHE_USERS_TABLE)
-    key_obj = {"username": username}
-    response = table_resource.get_item(TableName=CACHE_USERS_TABLE, Key=key_obj)
+    if username:
+        key_obj = {"username": username}
+        response = table_resource.get_item(TableName=CACHE_USERS_TABLE, Key=key_obj)
+    else:
+        response = table_resource.scan(TableName=CACHE_USERS_TABLE, IndexName="email",  FilterExpression = Attr('email').eq(email))
 
     return response["Item"]["slack_id"] if "Item" in response else False
 
-
-def save_user_to_cache(username: str, slack_id: str):
+def save_user_to_cache(username: str, email: str, slack_id: str):
     """Save a username -> slack_id mapping to the cache table
     Args:
         username: slack username
+        email: slack user's email
         slack_id: user's slack id
     """
     dynamodb = boto3.resource("dynamodb")
@@ -158,10 +204,9 @@ def save_user_to_cache(username: str, slack_id: str):
             "env var CACHE_USERS_TABLE is not set, please check socless-slack serverless.yml"
         )
     table_resource = dynamodb.Table(CACHE_USERS_TABLE)
-    new_item = {"username": username, "slack_id": slack_id}
+    new_item = {"username": username, "email": email, "slack_id": slack_id}
     response = table_resource.put_item(TableName=CACHE_USERS_TABLE, Item=new_item)
     print(response)
-
 
 def paginated_api_call(api_method, response_objects_name, **kwargs):
     """Calls api method and cycles through all pages to get all objects.

--- a/functions/find_user/lambda_function.py
+++ b/functions/find_user/lambda_function.py
@@ -14,15 +14,17 @@
 from socless import socless_bootstrap
 from slack_helpers import (
     SlackHelper,
+    SlackError
 )
 
 
 def handle_state(
-    username: str = "", slack_id: str = "", exclude_bots: bool = False, token: str = ""
+    username: str = "", email: str = "", slack_id: str = "", exclude_bots: bool = False, token: str = ""
 ):
-    """Get a slack user's profile from their username or slack_id.
+    """Get a slack user's profile from their username, email or slack_id.
     Args:
         username     : User's Slack name ex. ubalogun
+        email        : User's email ex. ubalogun@twilio.com
         slack_id     : user's Slack ID ex. W1234567
         exclude_bots : exclude bots from search results
         token        : you can pass an alternate token via Jinja template in playbook.json (ssm, environment, etc)
@@ -38,18 +40,31 @@ def handle_state(
             }
         }
     """
+    if not username and not email and not slack_id:
+        raise SlackError(
+            f"A username or email is required"
+        )
+
     helper = SlackHelper(token)
 
     if exclude_bots and isinstance(exclude_bots, str):
         lowered = exclude_bots.lower()
         if lowered not in ["true", "false"]:
-            raise Exception(
+            raise SlackError(
                 f"Invalid value passed for arg 'exclude_bots': {exclude_bots}. Arg must be type bool or string 'true|false' "
             )
         exclude_bots = True if lowered == "true" else False
 
-    if username and not slack_id:
-        slack_id = helper.get_slack_id_from_username(username)
+    if not slack_id:
+        if username:
+            try:
+                slack_id = helper.get_slack_id_from_username(username)
+            except Exception as e:
+                if not email:
+                    raise e
+                slack_id = helper.get_slack_id_from_email(email)
+        else:
+            slack_id = helper.get_slack_id_from_email(email)
 
     user = helper.get_user_info_via_id(slack_id)
     profile = user.get("profile", {})

--- a/resources/dynamodb.yml
+++ b/resources/dynamodb.yml
@@ -1,12 +1,14 @@
 # Dynamodb Tables
 Resources:
-  # Slack Usernames to slack_ids table
-  SlackUsernamesTable:
+  # Slack User info to slack_ids table
+  SlackUsersTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: socless_slack_usernames
+      TableName: socless_slack_users
       AttributeDefinitions:
         - AttributeName: username
+          AttributeType: S
+        - AttributeName: email
           AttributeType: S
       KeySchema:
         - AttributeName: username
@@ -14,11 +16,23 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: 10
         WriteCapacityUnits: 10
+      GlobalSecondaryIndexes:
+        - IndexName: email
+          KeySchema:
+            - AttributeName: email
+              KeyType: HASH
+          Projection:
+            NonKeyAttributes:
+              - slack_id
+            ProjectionType: INCLUDE
+          ProvisionedThroughput:
+            ReadCapacityUnits: 10
+            WriteCapacityUnits: 10
 
 # Resource outputs
 Outputs:
   # Slack Usernames Table name
-  SlackUsernamesTable:
-    Description: "SOCless Slack usernames to slack_ids table"
+  SlackUsersTable:
+    Description: "SOCless Slack userinfo to slack_ids table"
     Value:
-      Ref: SlackUsernamesTable
+      Ref: SlackUsersTable

--- a/serverless.yml
+++ b/serverless.yml
@@ -19,7 +19,7 @@ provider:
     MESSAGE_RESPONSES_TABLE: ${{cf:${{self:custom.socless}}.MessageResponsesTable}}
     SOCLESS_BOT_TOKEN: ${{ssm:/socless/slack/bot_token~true}} # default token if none specified via lambda args at runtime
     CACHE_USERS_TABLE:
-      Ref: SlackUsernamesTable
+      Ref: SlackUsersTable
     # Add Bot Tokens to the environment vars for multi-bot support.
     # <BOT_NAME>_TOKEN can be used in playbooks at runtime as "token" : "{{env('TSIRT_TOKEN')}}"
     # To enable interactivity, you will also need to add the bot signing secret under the


### PR DESCRIPTION
It will benefit if users can be found via email, adding this to give SOCless users to find a specific slack user either by the username or email. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
